### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering both detected ecosystems: `cargo` and `github-actions`
- Weekly schedule with grouped updates for both ecosystems

## Audit findings
- No prior Dependabot configuration existed
- Two ecosystems detected: Cargo (Rust dependencies) and GitHub Actions
- No `uv`/`pip` ecosystem needed (pure Rust project)

## Test plan
- [ ] Verify Dependabot starts creating PRs after merge
- [ ] Confirm grouped updates work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)